### PR TITLE
Add foyer section in notebook.

### DIFF
--- a/MoSDeF Workflow.ipynb
+++ b/MoSDeF Workflow.ipynb
@@ -134,9 +134,8 @@
    "outputs": [],
    "source": [
     "def apply_charges(box_structure, single_compound, n_atoms, ff):\n",
-    "    single_mol_struct = ff.apply(single_compound)\n",
     "    single_mol_struct_charge = antefoyer.ante_charges(\n",
-    "            single_mol_struct, 'bcc', net_charge=0.00, multiplicity=1)\n",
+    "            single_compound, 'bcc', net_charge=0.00, multiplicity=1)\n",
     "    \n",
     "    for index, atom in enumerate(box_structure.atoms):\n",
     "        atom.charge = single_mol_struct_charge.atoms[index%n_atoms].charge\n",


### PR DESCRIPTION
Adding the `foyer` section into the notebook, which applies the GAFF forcefield to the mbuild compound and assigns partial charges with antefoyer and antechamber.