### PR TITLE
Include environment.yml for mybinder

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: cmelab
+name: mosdef37
 channels:
   - conda-forge
   - mosdef


### PR DESCRIPTION
This adds a conda environment.yml file for mybinder links.

This will install from source gaff_foyer and antefoyer as well.